### PR TITLE
.gitignore: ignore .elixir_ls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tigerbeetlex-*.tar
 
 # Sometimes created in the root folder
 zig-cache/
+
+# Ignore .elixir_ls generated folder
+.elixir_ls/


### PR DESCRIPTION
I'll start with a simple contribution 🙂

As a user of VSCode, using the ElixirLS extension, this directory is generated when opening an Elixir file for the first time in the project. This repository should ignore this directory