### PR TITLE
docker-compose: build the Docker image locally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -95,10 +95,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Start Docker and wait for it to be up
+      - name: Build and start TigerBeetle and wait for it to be up
         working-directory: ./test/docker
+        env:
+          COMPOSE_DOCKER_CLI_BUILD: "1"
+          DOCKER_BUILDKIT: "1"
+          DOCKER_DEFAULT_PLATFORM: "linux/amd64"
         run: |
-          docker-compose up --detach
+          docker-compose up --detach --build
           ./health-check-services.sh
 
       - name: Install OTP and Elixir

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3'
 
 services:
   tigerbeetle:
-    image: ghcr.io/tigerbeetledb/tigerbeetle:0.13.36
+    platform: linux/amd64
+    build:
+      context: ../../src/tigerbeetle
     volumes:
       - tb-data:/data
     entrypoint: /bin/sh


### PR DESCRIPTION
Since we already clone the TigerBeetle repo, we can build the Docker image locally. This ensures that the runner builds it with the CPU features it supports, avoiding failing CI due to the default CPU baseline.
Moreover, this removes the need to manually bump TigerBeetle's version when updating the submodule.
Fix #16.