### PR TITLE
Restore build step to force the output name of the NIF library

### DIFF
--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -4,7 +4,7 @@ defmodule TigerBeetlex.NifAdapter do
   alias TigerBeetlex.Types
 
   @on_load :load_nif
-  @nif_path "priv/#{Mix.target()}/lib/libtigerbeetlex"
+  @nif_path "priv/#{Mix.target()}/lib/tigerbeetlex"
 
   defp load_nif do
     path = Application.app_dir(:tigerbeetlex, @nif_path)


### PR DESCRIPTION
Fix regression on MacOS