### PR TITLE
CI: use prebuilt TigerBeetle binaries instead of docker-compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,18 +79,24 @@ jobs:
       - name: Run Dialyzer
         run: mix dialyzer --format github
 
-  macos-build:
+  macos-test:
     runs-on: macos-13
-    name: Build on MacOS
+    name: Test on MacOS
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
         with:
           submodules: recursive
 
+      - name: Install and start TigerBeetle
+        working-directory: ./src/tigerbeetle
+        run: |
+          ./bootstrap.sh
+          ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
+          ./tigerbeetle start --addresses=3000 0_0.tigerbeetle &
+
       - name: Install Elixir
         run: |
-          brew update
           brew install elixir
 
       - name: Setup mix
@@ -98,13 +104,23 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
 
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+
       - name: Install and compile dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
-          mix deps.get
+          mix deps.get --only test
           mix deps.compile
 
-      - name: Build
-        run: mix compile
+      - name: Run tests
+        run: mix test
 
   test:
     name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,61 +79,21 @@ jobs:
       - name: Run Dialyzer
         run: mix dialyzer --format github
 
-  macos-test:
-    runs-on: macos-13
-    name: Test on MacOS
-    steps:
-      - name: Clone the repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Install and start TigerBeetle
-        working-directory: ./src/tigerbeetle
-        run: |
-          ./bootstrap.sh
-          ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
-          ./tigerbeetle start --addresses=3000 0_0.tigerbeetle &
-
-      - name: Install Elixir
-        run: |
-          brew install elixir
-
-      - name: Setup mix
-        run: |
-          mix local.hex --force
-          mix local.rebar --force
-
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v2
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-
-      - name: Install and compile dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          mix deps.get --only test
-          mix deps.compile
-
-      - name: Run tests
-        run: mix test
-
   test:
-    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}
-    runs-on: ubuntu-20.04
+    name: Test on ${{ matrix.os }} (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # TODO: add OTP 26 + Elixir 1.15, right now there seem to be some problems with setup-beam,
-          # see https://github.com/erlef/setup-beam/issues/220
-          - otp: "25.3"
+          - os: ubuntu-20.04
+            otp: "25.3"
             elixir: "1.14"
-          - otp: "26.0.2"
+          - os: ubuntu-22.04
+            otp: "26.0.2"
+            elixir: "1.15.2"
+          - os: macos-13
+            otp: "26.0.2"
             elixir: "1.15.2"
 
     steps:
@@ -150,10 +110,16 @@ jobs:
           ./tigerbeetle start --addresses=3000 0_0.tigerbeetle &
 
       - name: Install OTP and Elixir
+        if: runner.os == 'Linux'
         uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
+
+      - name: Install OTP and Elixir
+        if: runner.os == 'macOS'
+        run: |
+          brew install elixir
 
       - name: Cache dependencies
         id: cache-deps
@@ -162,7 +128,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ matrix.os }}-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
 
       - name: Install and compile dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,18 +126,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Start Docker and wait for it to be up
-        working-directory: ./test/docker
+      - name: Install and start TigerBeetle
+        working-directory: ./src/tigerbeetle
         run: |
-          docker-compose up --detach
-          ./health-check-services.sh
+          ./bootstrap.sh
+          ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 0_0.tigerbeetle
+          ./tigerbeetle start --addresses=3000 0_0.tigerbeetle &
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
@@ -162,7 +156,3 @@ jobs:
 
       - name: Run tests
         run: mix test
-
-      - name: Dump Docker logs on failure
-        uses: jwalton/gh-docker-logs@v1
-        if: failure()


### PR DESCRIPTION
Allow running tests on MacOS to provide a more robust CI