### PR TITLE
Update TigerBeetle to v0.14.168

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
           - os: ubuntu-22.04
             otp: "26.0.2"
             elixir: "1.15.2"
-          - os: macos-13
+          - os: macos-latest
             otp: "26.0.2"
             elixir: "1.15.2"
 

--- a/bench/benchmark.exs
+++ b/bench/benchmark.exs
@@ -5,14 +5,14 @@ alias TigerBeetlex.TransferBatch
 {:ok, _pid} =
   Connection.start_link(
     name: :tb,
-    cluster_id: 0,
+    cluster_id: <<0::128>>,
     addresses: ["3000"],
     concurrency_max: 1,
     partitions: 1
   )
 
 samples = 1_000_000
-batch_size = 8191
+batch_size = 8190
 
 bench = fn ->
   chunks =

--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -27,7 +27,7 @@ defmodule TigerBeetlex do
 
   ## Arguments
 
-  - `cluster_id` (`non_neg_integer/0`): - The TigerBeetle cluster id.
+  - `cluster_id` (128-bit binary ID): - The TigerBeetle cluster id.
   - `addresses` (list of `String.t()`) - The list of node addresses. These can either be a single
   digit (e.g. `"3000"`), which is interpreted as a port on `127.0.0.1`, an IP address + port (e.g.
   `"127.0.0.1:3000"`), or just an IP address (e.g. `"127.0.0.1"`), which defaults to port `3001`.
@@ -37,16 +37,16 @@ defmodule TigerBeetlex do
 
   ## Examples
 
-      {:ok, client} = TigerBeetlex.connect(0, ["3000"], 32)
+      {:ok, client} = TigerBeetlex.connect(<<0::128>>, ["3000"], 32)
   """
   @spec connect(
-          cluster_id :: non_neg_integer(),
+          cluster_id :: Types.id_128(),
           addresses :: [binary()],
           concurrency_max :: pos_integer()
         ) ::
           {:ok, t()} | {:error, Types.client_init_error()}
-  def connect(cluster_id, addresses, concurrency_max)
-      when cluster_id >= 0 and is_list(addresses) and is_integer(concurrency_max) and
+  def connect(<<_::128>> = cluster_id, addresses, concurrency_max)
+      when is_list(addresses) and is_integer(concurrency_max) and
              concurrency_max > 0 do
     joined_addresses = Enum.join(addresses, ",")
 

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -27,7 +27,8 @@ defmodule TigerBeetlex.Connection do
       """
     ],
     cluster_id: [
-      type: :non_neg_integer,
+      type: {:custom, TigerBeetlex.ID128, :validate, []},
+      type_doc: "`t:TigerBeetlex.Types.id_128/0`",
       required: true,
       doc: "The TigerBeetle cluster id."
     ],
@@ -85,7 +86,7 @@ defmodule TigerBeetlex.Connection do
       # Start the TigerBeetlex connection
       {:ok, pid} =
         TigerBeetlex.Connection.start_link(
-          cluster_id: 0,
+          cluster_id: <<0::128>>,
           addresses: ["3000"],
           concurrency_max: 32
         )
@@ -93,7 +94,7 @@ defmodule TigerBeetlex.Connection do
       # Start a named TigerBeetlex connection
       {:ok, pid} =
         TigerBeetlex.Connection.start_link(
-          cluster_id: 0,
+          cluster_id: <<0::128>>,
           addresses: ["3000"],
           concurrency_max: 32,
           name: :tb

--- a/lib/tigerbeetlex/id_128.ex
+++ b/lib/tigerbeetlex/id_128.ex
@@ -1,0 +1,5 @@
+defmodule TigerBeetlex.ID128 do
+  @moduledoc false
+  def validate(<<_::128>> = value), do: {:ok, value}
+  def validate(_other), do: {:error, "not a valid 128-bit binary"}
+end

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -12,7 +12,7 @@ defmodule TigerBeetlex.NifAdapter do
   end
 
   @spec client_init(
-          cluster_id :: non_neg_integer(),
+          cluster_id :: Types.id_128(),
           addresses :: binary(),
           concurrency_max :: pos_integer()
         ) ::

--- a/src/client.zig
+++ b/src/client.zig
@@ -24,7 +24,7 @@ const RequestContext = struct {
     payload_raw_obj: *anyopaque,
 };
 
-pub fn init(env: beam.Env, cluster_id: u32, addresses: []const u8, concurrency_max: u32) beam.Term {
+pub fn init(env: beam.Env, cluster_id: u128, addresses: []const u8, concurrency_max: u32) beam.Term {
     const client: tb_client.tb_client_t = tb_client.init(
         beam.general_purpose_allocator,
         cluster_id,

--- a/test/tigerbeetlex/connection_test.exs
+++ b/test/tigerbeetlex/connection_test.exs
@@ -7,7 +7,7 @@ defmodule TigerBeetlex.ConnectionTest do
     setup do
       valid_opts = [
         name: :tb,
-        cluster_id: 0,
+        cluster_id: <<0::128>>,
         addresses: ["3000"],
         concurrency_max: 32
       ]
@@ -16,7 +16,7 @@ defmodule TigerBeetlex.ConnectionTest do
     end
 
     test "raises with invalid cluster_id", %{valid_opts: opts} do
-      opts = Keyword.put(opts, :cluster_id, "foobar")
+      opts = Keyword.put(opts, :cluster_id, 0)
 
       assert_raise NimbleOptions.ValidationError, fn ->
         Connection.start_link(opts)


### PR DESCRIPTION
This has mainly two implcations:
- `cluster_id` is now a 128-bit ID instead of a u32 integer
- The max batch size is now 8190, now 8191 Add a test to cover the max batch size since that was not caught by the previous integration test (but was caught while running the benchmark manually).