### PR TITLE
Use Zig package manager instead of Git submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
@@ -102,23 +100,18 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Fetch TigerBeetle for Linux
         if: runner.os == 'Linux'
-        working-directory: ./src/tigerbeetle
         run: |
           curl -Lo tigerbeetle.zip https://linux.tigerbeetle.com && unzip tigerbeetle.zip
 
       - name: Fetch TigerBeetle for Mac
         if: runner.os == 'macOS'
-        working-directory: ./src/tigerbeetle
         run: |
           curl -Lo tigerbeetle.zip https://mac.tigerbeetle.com && unzip tigerbeetle.zip
 
       - name: Start TigerBeetle
-        working-directory: ./src/tigerbeetle
         run: |
           ./tigerbeetle format --cluster=0 --replica=0 --replica-count=1 --development 0_0.tigerbeetle
           ./tigerbeetle start --addresses=3000 --development 0_0.tigerbeetle &

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/tigerbeetle"]
-	path = src/tigerbeetle
-	url = git@github.com:tigerbeetledb/tigerbeetle.git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package can be installed by adding `tigerbeetlex` to your list of dependenci
 ```elixir
 def deps do
   [
-    {:tigerbeetlex, github: "rbino/tigerbeetlex", submodules: true}
+    {:tigerbeetlex, github: "rbino/tigerbeetlex"}
   ]
 end
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,36 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "tigerbeetlex",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    .minimum_zig_version = "0.13.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        .tigerbeetle = .{
+            .url = "https://github.com/tigerbeetle/tigerbeetle/archive/refs/tags/0.15.4.tar.gz",
+            .hash = "1220df4340b291f24f4bb7346b7ed6fe06109eb79526c56b6ac85738e25519ad2ed7",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,12 @@
 defmodule TigerBeetlex.MixProject do
   use Mix.Project
 
+  @release_regex ~r{https://github.com/tigerbeetle/tigerbeetle/archive/refs/tags/(?<release>[0-9]+\.[0-9]+\.[0-9]+)\.tar\.gz}
+
+  @tigerbeetle_release File.read!("build.zig.zon")
+                       |> then(&Regex.named_captures(@release_regex, &1))
+                       |> Map.fetch!("release")
+
   def project do
     [
       app: :tigerbeetlex,
@@ -8,6 +14,7 @@ defmodule TigerBeetlex.MixProject do
       elixir: "~> 1.14",
       install_zig: "0.13.0",
       zig_build_mode: zig_build_mode(Mix.env()),
+      zig_extra_options: [tigerbeetle_release: @tigerbeetle_release],
       compilers: [:build_dot_zig] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       dialyzer: [plt_add_apps: [:zig_parser]],

--- a/src/account_batch.zig
+++ b/src/account_batch.zig
@@ -5,7 +5,7 @@ const batch = @import("batch.zig");
 const beam = @import("beam.zig");
 const scheduler = beam.scheduler;
 
-const tb = @import("tigerbeetle/src/tigerbeetle.zig");
+const tb = @import("vsr").tigerbeetle;
 const Account = tb.Account;
 const AccountFlags = tb.AccountFlags;
 pub const AccountBatch = batch.Batch(Account);

--- a/src/batch.zig
+++ b/src/batch.zig
@@ -4,7 +4,7 @@ const RwLock = std.Thread.RwLock;
 const beam = @import("beam.zig");
 const Resource = beam.resource.Resource;
 
-const tb = @import("tigerbeetle/src/tigerbeetle.zig");
+const tb = @import("vsr").tigerbeetle;
 const Account = tb.Account;
 const Transfer = tb.Transfer;
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -6,8 +6,8 @@ const process = beam.process;
 const resource = beam.resource;
 const Resource = resource.Resource;
 
-const tb = @import("tigerbeetle/src/tigerbeetle.zig");
-const tb_client = @import("tigerbeetle/src/clients/c/tb_client.zig");
+const tb = @import("vsr").tigerbeetle;
+const tb_client = @import("vsr").tb_client;
 const Account = tb.Account;
 const Transfer = tb.Transfer;
 

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -17,19 +17,6 @@ const AccountBatchResource = account_batch.AccountBatchResource;
 const IdBatchResource = id_batch.IdBatchResource;
 const TransferBatchResource = transfer_batch.TransferBatchResource;
 
-pub const vsr_options = .{
-    .config_base = .default,
-    .config_log_level = std.log.Level.info,
-    .tracer_backend = .none,
-    .hash_log_mode = .none,
-    .git_commit = null,
-    // TODO: take these from a proper place
-    .release = "0.15.4",
-    .release_client_min = "0.15.4",
-    .config_aof_record = false,
-    .config_aof_recovery = false,
-};
-
 pub const std_options = .{
     .log_level = .err,
 };

--- a/src/transfer_batch.zig
+++ b/src/transfer_batch.zig
@@ -5,7 +5,7 @@ const batch = @import("batch.zig");
 const beam = @import("beam.zig");
 const scheduler = beam.scheduler;
 
-const tb = @import("tigerbeetle/src/tigerbeetle.zig");
+const tb = @import("vsr").tigerbeetle;
 const Transfer = tb.Transfer;
 const TransferFlags = tb.TransferFlags;
 pub const TransferBatch = batch.Batch(Transfer);


### PR DESCRIPTION
Retrieve TigerBeetle using the Zig package manager instead of using Git submodules to clone it.
Also remove hardcoded vsr_options struct and use the defaults provided by TigerBeetle's build.zig (except for release and release_client_min, which are needed to correctly connect to a cluster)