### PR TITLE
Add query_accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tigerbeetlex-*.tar
 
 # Sometimes created in the root folder
 zig-cache/
+.zig-cache/
 
 # Ignore .elixir_ls generated folder
 .elixir_ls/

--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -34,7 +34,7 @@ defmodule TigerBeetlex do
 
   ## Examples
 
-      {:ok, client} = TigerBeetlex.connect(<<0::128>>, ["3000"], 32)
+      {:ok, client} = TigerBeetlex.connect(<<0::128>>, ["3000"])
   """
   @spec connect(
           cluster_id :: Types.id_128(),

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -100,4 +100,8 @@ defmodule TigerBeetlex.NifAdapter do
   @spec lookup_transfers(client :: Types.client(), id_batch :: Types.id_batch()) ::
           {:ok, reference()} | {:error, Types.lookup_transfers_error()}
   def lookup_transfers(_client, _id_batch), do: :erlang.nif_error(:nif_not_loaded)
+
+  # @spec encode_query_filter(query_filter :: Types.query_filter()) ::
+  #         {:ok, Types.query_filter()} | {:error, Types.encode_query_filter_error()}
+  def encode_query_filter(_query_filter), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -101,7 +101,7 @@ defmodule TigerBeetlex.NifAdapter do
           {:ok, reference()} | {:error, Types.lookup_transfers_error()}
   def lookup_transfers(_client, _id_batch), do: :erlang.nif_error(:nif_not_loaded)
 
-  # @spec encode_query_filter(query_filter :: Types.query_filter()) ::
-  #         {:ok, Types.query_filter()} | {:error, Types.encode_query_filter_error()}
-  def encode_query_filter(_query_filter), do: :erlang.nif_error(:nif_not_loaded)
+  # @spec encode_query_filter(client :: Types.client(), query_filter :: Types.query_filter()) ::
+  #         {:ok, reference()} | {:error, Types.query_accounts_error()}
+  def query_accounts(_client, _query_filter), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/tigerbeetlex/query_filter.ex
+++ b/lib/tigerbeetlex/query_filter.ex
@@ -55,10 +55,12 @@ defmodule TigerBeetlex.QueryFilter do
 
     <<user_data_128_default(user_data_128)::binary-size(16),
       user_data_64_default(user_data_64)::binary-size(8),
-      user_data_32_default(user_data_32)::binary-size(4), ledger::unsigned-little-32,
-      code::unsigned-little-16, timestamp_min::unsigned-little-64,
-      timestamp_max::unsigned-little-64, limit::unsigned-little-32, limit::unsigned-little-32,
-      flags_u32::unsigned-little-32, reserved::binary>>
+      user_data_32_default(user_data_32)::binary-size(4),
+      value_or_zero(ledger)::unsigned-little-32, value_or_zero(code)::unsigned-little-16,
+      value_or_zero(timestamp_min)::unsigned-little-64,
+      value_or_zero(timestamp_max)::unsigned-little-64, value_or_zero(limit)::unsigned-little-32,
+      value_or_zero(limit)::unsigned-little-32, value_or_zero(flags_u32)::unsigned-little-32,
+      reserved::binary>>
   end
 
   defp user_data_128_default(nil), do: <<0::unit(8)-size(16)>>
@@ -69,4 +71,7 @@ defmodule TigerBeetlex.QueryFilter do
 
   defp user_data_32_default(nil), do: <<0::unit(8)-size(4)>>
   defp user_data_32_default(value), do: value
+
+  defp value_or_zero(nil), do: 0
+  defp value_or_zero(value), do: value
 end

--- a/lib/tigerbeetlex/query_filter.ex
+++ b/lib/tigerbeetlex/query_filter.ex
@@ -1,0 +1,72 @@
+defmodule TigerBeetlex.QueryFilter do
+  @moduledoc """
+  QueryFilter creation and manipulation.
+
+  This module collects functions to interact with a query filter. A Query Filter represents a struct that will be used to submit a Query Accounts or Query Transfers
+  operation on TigerBeetle.
+
+  The Query Filter should be treated as an opaque and underneath it is implemented with a mutable NIF
+  resource. It is safe to modify an ID Batch from multiple processes concurrently.
+
+  See https://docs.tigerbeetle.com/reference/query-filter/#fields
+  """
+
+  alias TigerBeetlex.QueryFilter
+  alias TigerBeetlex.QueryFilter.Flags
+  alias TigerBeetlex.Types
+  use TypedStruct
+
+  typedstruct do
+    field :user_data_128, Types.user_data_128()
+    field :user_data_64, Types.user_data_64()
+    field :user_data_32, Types.user_data_32()
+    field :ledger, non_neg_integer()
+    field :code, non_neg_integer()
+    field :timestamp_min, non_neg_integer()
+    field :timestamp_max, non_neg_integer()
+    field :limit, non_neg_integer()
+
+    field :flags, %Flags{}
+  end
+
+  @doc """
+  Converts a `%TigerBeetlex.QueryFilter{}` to its binary representation (?? bytes
+  binary).
+  """
+  # @spec encode(query_filter :: t()) :: Types.account_binary()
+  def encode(%QueryFilter{} = query_filter) do
+    %QueryFilter{
+      user_data_128: user_data_128,
+      user_data_64: user_data_64,
+      user_data_32: user_data_32,
+      ledger: ledger,
+      code: code,
+      timestamp_min: timestamp_min,
+      timestamp_max: timestamp_max,
+      limit: limit,
+      flags: flags
+    } = query_filter
+
+    reserved = <<0::unit(8)-size(6)>>
+
+    flags_u32 =
+      (flags || %Flags{})
+      |> Flags.to_u32!()
+
+    <<user_data_128_default(user_data_128)::binary-size(16),
+      user_data_64_default(user_data_64)::binary-size(8),
+      user_data_32_default(user_data_32)::binary-size(4), ledger::unsigned-little-32,
+      code::unsigned-little-16, timestamp_min::unsigned-little-64,
+      timestamp_max::unsigned-little-64, limit::unsigned-little-32, limit::unsigned-little-32,
+      flags_u32::unsigned-little-32, reserved::binary>>
+  end
+
+  defp user_data_128_default(nil), do: <<0::unit(8)-size(16)>>
+  defp user_data_128_default(value), do: value
+
+  defp user_data_64_default(nil), do: <<0::unit(8)-size(8)>>
+  defp user_data_64_default(value), do: value
+
+  defp user_data_32_default(nil), do: <<0::unit(8)-size(4)>>
+  defp user_data_32_default(value), do: value
+end

--- a/lib/tigerbeetlex/query_filter/flags.ex
+++ b/lib/tigerbeetlex/query_filter/flags.ex
@@ -1,0 +1,32 @@
+defmodule TigerBeetlex.QueryFilter.Flags do
+  @moduledoc """
+    See https://docs.tigerbeetle.com/reference/query-filter#flags
+  """
+
+  use TypedStruct
+  alias TigerBeetlex.QueryFilter.Flags
+
+  typedstruct do
+    field :reversed, boolean(), default: false
+  end
+
+  @doc """
+  Converts a `%Tigerbeetlex.QueryFilter.Flags{}` struct to its integer representation (32 bit unsigned
+  int)
+  """
+  @spec to_u32!(flags :: t()) :: non_neg_integer()
+  def to_u32!(%Flags{} = flags) do
+    %Flags{
+      reversed: reversed
+    } = flags
+
+    # We use big endian for the destination number so we can just follow the (reverse) order of
+    # the struct for the fields without manually swapping bytes
+    <<n::unsigned-big-32>> = <<_padding = 0::31, bool_to_u1(reversed)::1>>
+    n
+  end
+
+  @spec bool_to_u1(b :: boolean()) :: 0 | 1
+  defp bool_to_u1(false), do: 0
+  defp bool_to_u1(true), do: 1
+end

--- a/lib/tigerbeetlex/types.ex
+++ b/lib/tigerbeetlex/types.ex
@@ -25,6 +25,8 @@ defmodule TigerBeetlex.Types do
 
   @type user_data_32 :: <<_::32>>
 
+  @type query_filter :: <<_::64>>
+
   @type client_init_error ::
           :unexpected
           | :out_of_memory

--- a/src/client.zig
+++ b/src/client.zig
@@ -60,8 +60,8 @@ fn OperationBatchItemType(comptime operation: tb_client.tb_operation_t) type {
     return switch (operation) {
         .create_accounts => Account,
         .create_transfers => Transfer,
-        .lookup_accounts, .lookup_transfers => u128,
-        .get_account_transfers, .get_account_balances, .query_accounts, .query_transfers => @panic("TODO"),
+        .lookup_accounts, .lookup_transfers, .query_accounts => u128,
+        .get_account_transfers, .get_account_balances, .query_transfers => @panic("TODO"),
         .pulse => unreachable,
     };
 }
@@ -76,6 +76,7 @@ const SubmitError = error{
 pub const create_accounts = get_submit_fn(.create_accounts);
 pub const create_transfers = get_submit_fn(.create_transfers);
 pub const lookup_accounts = get_submit_fn(.lookup_accounts);
+pub const query_accounts = get_submit_fn(.query_accounts);
 pub const lookup_transfers = get_submit_fn(.lookup_transfers);
 
 fn get_submit_fn(comptime operation: tb_client.tb_operation_t) (fn (

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -39,6 +39,7 @@ var exported_nifs = [_]nif.FunctionEntry{
     nif.wrap("create_accounts", client.create_accounts),
     nif.wrap("create_transfers", client.create_transfers),
     nif.wrap("lookup_accounts", client.lookup_accounts),
+    nif.wrap("query_accounts", client.query_accounts),
     nif.wrap("lookup_transfers", client.lookup_transfers),
     nif.wrap("create_account_batch", account_batch.create),
     nif.wrap("append_account", account_batch.append),

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -812,6 +812,21 @@ defmodule TigerBeetlex.IntegrationTest do
     end
   end
 
+  describe "query_accounts/2" do
+    test "query accounts by timestamp_min" do
+      # create account
+      # sleep 1 ms
+      timestamp = System.os_time(:nanosecond)
+      # create second account
+      query_filter = %TigerBeetlex.QueryFilter{
+        timestamp_min: timestamp,
+        flags: %TigerBeetlex.QueryFilter.Flags{}
+      }
+
+      # assert query accounts returns only second account
+    end
+  end
+
   defp random_id do
     Uniq.UUID.uuid7(:raw)
   end


### PR DESCRIPTION
Hey @rbino I'd love to contribute by adding the `query_accounts` function but that will require a bit of hand-holding and guidance. 

As the first step I added `TigerBeetlex.QueryFilter`  struct and I guess the next step is to encode it so that it can be passed in the `query_accounts`. 

Is that how you see it? 