### PR TITLE
Bump to 16.18 and add support for get_account_balances and get_account_transfers

### DIFF
--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -200,7 +200,7 @@ defmodule TigerBeetlex do
   end
 
   def get_account_transfers(%__MODULE__{} = client, %AccountFilterBatch{} = batch) do
-    NifAdapter.get_account_balances(client.ref, batch.ref)
+    NifAdapter.get_account_transfers(client.ref, batch.ref)
   end
 
   @doc """

--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -13,6 +13,7 @@ defmodule TigerBeetlex do
     field :ref, reference(), enforce: true
   end
 
+  alias TigerBeetlex.AccountFilterBatch
   alias TigerBeetlex.AccountBatch
   alias TigerBeetlex.IDBatch
   alias TigerBeetlex.NifAdapter
@@ -192,6 +193,14 @@ defmodule TigerBeetlex do
           {:ok, reference()} | {:error, Types.create_transfers_error()}
   def create_transfers(%__MODULE__{} = client, %TransferBatch{} = transfer_batch) do
     NifAdapter.create_transfers(client.ref, transfer_batch.ref)
+  end
+
+  def get_account_balances(%__MODULE__{} = client, %AccountFilterBatch{} = batch) do
+    NifAdapter.get_account_balances(client.ref, batch.ref)
+  end
+
+  def get_account_transfers(%__MODULE__{} = client, %AccountFilterBatch{} = batch) do
+    NifAdapter.get_account_balances(client.ref, batch.ref)
   end
 
   @doc """

--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -13,8 +13,8 @@ defmodule TigerBeetlex do
     field :ref, reference(), enforce: true
   end
 
-  alias TigerBeetlex.AccountFilterBatch
   alias TigerBeetlex.AccountBatch
+  alias TigerBeetlex.AccountFilterBatch
   alias TigerBeetlex.IDBatch
   alias TigerBeetlex.NifAdapter
   alias TigerBeetlex.TransferBatch

--- a/lib/tigerbeetlex/account/flags.ex
+++ b/lib/tigerbeetlex/account/flags.ex
@@ -16,9 +16,12 @@ defmodule TigerBeetlex.Account.Flags do
   typedstruct do
     @typedoc "A struct representing TigerBeetle account flags"
 
+    field :closed, boolean(), default: false
+    field :imported, boolean(), default: false
     field :linked, boolean(), default: false
     field :debits_must_not_exceed_credits, boolean(), default: false
     field :credits_must_not_exceed_debits, boolean(), default: false
+    field :history, boolean(), default: false
   end
 
   @doc """
@@ -29,10 +32,19 @@ defmodule TigerBeetlex.Account.Flags do
   def from_u16!(n) when n >= 0 and n < 65_536 do
     # We use big endian for the source number so we can just follow the (reverse) order of
     # the struct for the fields without manually swapping bytes
-    <<_padding::13, credits_must_not_exceed_debits::1, debits_must_not_exceed_credits::1,
-      linked::1>> = <<n::unsigned-big-16>>
+    <<_padding::10,
+      closed::1,
+      imported::1,
+      history::1,
+      credits_must_not_exceed_debits::1,
+      debits_must_not_exceed_credits::1,
+      linked::1
+    >> = <<n::unsigned-big-16>>
 
     %Flags{
+      closed: closed == 1,
+      imported: imported == 1,
+      history: history == 1,
       linked: linked == 1,
       debits_must_not_exceed_credits: debits_must_not_exceed_credits == 1,
       credits_must_not_exceed_debits: credits_must_not_exceed_debits == 1
@@ -48,14 +60,22 @@ defmodule TigerBeetlex.Account.Flags do
     %Flags{
       linked: linked,
       debits_must_not_exceed_credits: debits_must_not_exceed_credits,
-      credits_must_not_exceed_debits: credits_must_not_exceed_debits
+      credits_must_not_exceed_debits: credits_must_not_exceed_debits,
+      closed: closed,
+      imported: imported,
+      history: history,
     } = flags
 
     # We use big endian for the destination number so we can just follow the (reverse) order of
     # the struct for the fields without manually swapping bytes
     <<n::unsigned-big-16>> =
-      <<_padding = 0::13, bool_to_u1(credits_must_not_exceed_debits)::1,
-        bool_to_u1(debits_must_not_exceed_credits)::1, bool_to_u1(linked)::1>>
+      <<_padding = 0::10,
+        bool_to_u1(closed)::1,
+        bool_to_u1(imported)::1,
+        bool_to_u1(history)::1,
+        bool_to_u1(credits_must_not_exceed_debits)::1,
+        bool_to_u1(debits_must_not_exceed_credits)::1,
+        bool_to_u1(linked)::1>>
 
     n
   end

--- a/lib/tigerbeetlex/account/flags.ex
+++ b/lib/tigerbeetlex/account/flags.ex
@@ -32,14 +32,8 @@ defmodule TigerBeetlex.Account.Flags do
   def from_u16!(n) when n >= 0 and n < 65_536 do
     # We use big endian for the source number so we can just follow the (reverse) order of
     # the struct for the fields without manually swapping bytes
-    <<_padding::10,
-      closed::1,
-      imported::1,
-      history::1,
-      credits_must_not_exceed_debits::1,
-      debits_must_not_exceed_credits::1,
-      linked::1
-    >> = <<n::unsigned-big-16>>
+    <<_padding::10, closed::1, imported::1, history::1, credits_must_not_exceed_debits::1,
+      debits_must_not_exceed_credits::1, linked::1>> = <<n::unsigned-big-16>>
 
     %Flags{
       closed: closed == 1,
@@ -63,19 +57,15 @@ defmodule TigerBeetlex.Account.Flags do
       credits_must_not_exceed_debits: credits_must_not_exceed_debits,
       closed: closed,
       imported: imported,
-      history: history,
+      history: history
     } = flags
 
     # We use big endian for the destination number so we can just follow the (reverse) order of
     # the struct for the fields without manually swapping bytes
     <<n::unsigned-big-16>> =
-      <<_padding = 0::10,
-        bool_to_u1(closed)::1,
-        bool_to_u1(imported)::1,
-        bool_to_u1(history)::1,
+      <<_padding = 0::10, bool_to_u1(closed)::1, bool_to_u1(imported)::1, bool_to_u1(history)::1,
         bool_to_u1(credits_must_not_exceed_debits)::1,
-        bool_to_u1(debits_must_not_exceed_credits)::1,
-        bool_to_u1(linked)::1>>
+        bool_to_u1(debits_must_not_exceed_credits)::1, bool_to_u1(linked)::1>>
 
     n
   end

--- a/lib/tigerbeetlex/account_balance.ex
+++ b/lib/tigerbeetlex/account_balance.ex
@@ -38,7 +38,7 @@ defmodule TigerBeetlex.AccountBalance do
       debits_pending: debits_pending,
       debits_posted: debits_posted,
       credits_pending: credits_pending,
-      credits_posted: credits_posted,
+      credits_posted: credits_posted
     }
   end
 end

--- a/lib/tigerbeetlex/account_balance.ex
+++ b/lib/tigerbeetlex/account_balance.ex
@@ -1,0 +1,44 @@
+defmodule TigerBeetlex.AccountBalance do
+  @moduledoc """
+  AccountBalance struct module.
+
+  This module defines a struct that represents a TigerBeetle account-balance.
+
+  See [TigerBeetle docs](https://docs.tigerbeetle.com/reference/accounts) for the meaning of the
+  fields.
+  """
+
+  use TypedStruct
+
+  alias TigerBeetlex.AccountBalance
+  alias TigerBeetlex.Types
+
+  typedstruct do
+    @typedoc "A struct representing a TigerBeetle account-balance"
+
+    field :timestamp, non_neg_integer()
+    field :debits_pending, non_neg_integer()
+    field :debits_posted, non_neg_integer()
+    field :credits_pending, non_neg_integer()
+    field :credits_posted, non_neg_integer()
+  end
+
+  @doc """
+  Converts the binary representation of an account-balance (128 bytes) in a
+  `%TigerBeetlex.AccountBalance{}` struct
+  """
+  @spec from_binary(bin :: Types.account_binary()) :: t()
+  def from_binary(<<_::binary-size(128)>> = bin) do
+    <<debits_pending::unsigned-little-128, debits_posted::unsigned-little-128,
+      credits_pending::unsigned-little-128, credits_posted::unsigned-little-128,
+      timestamp::unsigned-little-64, _reserved::binary-size(56)>> = bin
+
+    %AccountBalance{
+      timestamp: timestamp,
+      debits_pending: debits_pending,
+      debits_posted: debits_posted,
+      credits_pending: credits_pending,
+      credits_posted: credits_posted,
+    }
+  end
+end

--- a/lib/tigerbeetlex/account_filter.ex
+++ b/lib/tigerbeetlex/account_filter.ex
@@ -50,16 +50,11 @@ defmodule TigerBeetlex.AccountFilter do
 
     flags_u32 = (flags || %Flags{}) |> Flags.to_u32!()
 
-    <<account_id::binary-size(16),
-      user_data_128_default(user_data_128)::binary-size(16),
+    <<account_id::binary-size(16), user_data_128_default(user_data_128)::binary-size(16),
       user_data_64_default(user_data_64)::binary-size(8),
-      user_data_32_default(user_data_32)::binary-size(4), 
-      code::unsigned-little-16,
-      reserved::binary,
-      timestamp_min::unsigned-little-64,
-      timestamp_max::unsigned-little-64,
-      limit::unsigned-little-32,
-      flags_u32::unsigned-little-32>>
+      user_data_32_default(user_data_32)::binary-size(4), code::unsigned-little-16,
+      reserved::binary, timestamp_min::unsigned-little-64, timestamp_max::unsigned-little-64,
+      limit::unsigned-little-32, flags_u32::unsigned-little-32>>
   end
 
   defp user_data_128_default(nil), do: <<0::unit(8)-size(16)>>

--- a/lib/tigerbeetlex/account_filter.ex
+++ b/lib/tigerbeetlex/account_filter.ex
@@ -32,7 +32,6 @@ defmodule TigerBeetlex.AccountFilter do
   Converts a `%TigerBeetlex.AccountFilter{}` to its binary representation (128 bytes
   binary).
   """
-  # TODO @spec to_binary(account :: t()) :: Types.account_binary()
   def to_batch_item(%AccountFilter{} = filter) do
     %AccountFilter{
       account_id: account_id,

--- a/lib/tigerbeetlex/account_filter.ex
+++ b/lib/tigerbeetlex/account_filter.ex
@@ -1,0 +1,73 @@
+defmodule TigerBeetlex.AccountFilter do
+  @moduledoc """
+  AccountFilter struct module.
+
+  This module defines a struct that represents a TigerBeetle account-filter.
+
+  See [TigerBeetle docs](https://docs.tigerbeetle.com/reference/account-filter) for the meaning of the
+  fields.
+  """
+
+  use TypedStruct
+
+  alias TigerBeetlex.AccountFilter
+  alias TigerBeetlex.AccountFilter.Flags
+  alias TigerBeetlex.Types
+
+  typedstruct do
+    @typedoc "A struct representing a TigerBeetle account-filter"
+
+    field :account_id, Types.id_128(), enforce: true
+    field :user_data_128, Types.user_data_128()
+    field :user_data_64, Types.user_data_64()
+    field :user_data_32, Types.user_data_32()
+    field :code, non_neg_integer(), default: 0
+    field :timestamp_min, non_neg_integer(), default: 0
+    field :timestamp_max, non_neg_integer(), default: 0
+    field :limit, non_neg_integer(), default: 8190
+    field :flags, Flags.t(), default: %Flags{}
+  end
+
+  @doc """
+  Converts a `%TigerBeetlex.AccountFilter{}` to its binary representation (128 bytes
+  binary).
+  """
+  # TODO @spec to_binary(account :: t()) :: Types.account_binary()
+  def to_batch_item(%AccountFilter{} = filter) do
+    %AccountFilter{
+      account_id: account_id,
+      user_data_128: user_data_128,
+      user_data_64: user_data_64,
+      user_data_32: user_data_32,
+      code: code,
+      timestamp_min: timestamp_min,
+      timestamp_max: timestamp_max,
+      limit: limit,
+      flags: flags
+    } = filter
+
+    reserved = <<0::unit(8)-size(58)>>
+
+    flags_u32 = (flags || %Flags{}) |> Flags.to_u32!()
+
+    <<account_id::binary-size(16),
+      user_data_128_default(user_data_128)::binary-size(16),
+      user_data_64_default(user_data_64)::binary-size(8),
+      user_data_32_default(user_data_32)::binary-size(4), 
+      code::unsigned-little-16,
+      reserved::binary,
+      timestamp_min::unsigned-little-64,
+      timestamp_max::unsigned-little-64,
+      limit::unsigned-little-32,
+      flags_u32::unsigned-little-32>>
+  end
+
+  defp user_data_128_default(nil), do: <<0::unit(8)-size(16)>>
+  defp user_data_128_default(value), do: value
+
+  defp user_data_64_default(nil), do: <<0::unit(8)-size(8)>>
+  defp user_data_64_default(value), do: value
+
+  defp user_data_32_default(nil), do: <<0::unit(8)-size(4)>>
+  defp user_data_32_default(value), do: value
+end

--- a/lib/tigerbeetlex/account_filter/flags.ex
+++ b/lib/tigerbeetlex/account_filter/flags.ex
@@ -1,0 +1,64 @@
+defmodule TigerBeetlex.AccountFilter.Flags do
+  @moduledoc """
+  AccountFilter Flags.
+
+  This module defines a struct that represents the flags for a TigerBeetle AccountFilter. Flags are all
+  false by default.
+
+  See [TigerBeetle docs](https://docs.tigerbeetle.com/reference/account-filter/#flags) for the meaning
+  of the flags.
+  """
+
+  use TypedStruct
+
+  alias TigerBeetlex.AccountFilter.Flags
+
+  typedstruct do
+    @typedoc "A struct representing TigerBeetle transfer flags"
+
+    field :debits, boolean(), default: false
+    field :credits, boolean(), default: false
+    field :reversed, boolean(), default: false
+  end
+
+  @doc """
+  Converts the integer representation of flags (16 bit unsigned int) in a
+  `%TigerBeetlex.AccountFilter.Flags{}` struct
+  """
+  @spec from_u32!(n :: non_neg_integer()) :: t()
+  def from_u32!(n) when n >= 0 and n < 4_294_967_296 do
+    # We use big endian for the source number so we can just follow the (reverse) order of
+    # the struct for the fields without manually swapping bytes
+    <<_padding::29, reversed::1, credits::1, debits::1>> = <<n::unsigned-big-32>>
+
+    %Flags{
+      reversed: reversed == 1,
+      credits: credits == 1,
+      debits: debits == 1
+    }
+  end
+
+  @doc """
+  Converts a `%TigerBeetlex.AccountFilter.Flags{}` struct to its integer representation (16 bit unsigned
+  int)
+  """
+  @spec to_u32!(flags :: t()) :: non_neg_integer()
+  def to_u32!(%Flags{} = flags) do
+    %Flags{
+      reversed: reversed,
+      credits: credits,
+      debits: debits
+    } = flags
+
+    # We use big endian for the destination number so we can just follow the (reverse) order of
+    # the struct for the fields without manually swapping bytes
+    <<n::unsigned-big-32>> =
+      <<_padding = 0::29, bool_to_u1(reversed)::1, bool_to_u1(credits)::1, bool_to_u1(debits)::1>>
+
+    n
+  end
+
+  @spec bool_to_u1(b :: boolean()) :: 0 | 1
+  defp bool_to_u1(false), do: 0
+  defp bool_to_u1(true), do: 1
+end

--- a/lib/tigerbeetlex/account_filter_batch.ex
+++ b/lib/tigerbeetlex/account_filter_batch.ex
@@ -1,0 +1,49 @@
+defmodule TigerBeetlex.AccountFilterBatch do
+  @moduledoc """
+  Account Filter Batch creation and manipulation.
+  """
+
+  use TypedStruct
+
+  typedstruct do
+    field :ref, reference(), enforce: true
+  end
+
+  alias TigerBeetlex.AccountFilter
+  alias TigerBeetlex.AccountFilterBatch
+  alias TigerBeetlex.InvalidBatchError
+  alias TigerBeetlex.NifAdapter
+  alias TigerBeetlex.OutOfBoundsError
+  alias TigerBeetlex.OutOfMemoryError
+  alias TigerBeetlex.Types
+
+  @doc """
+  Creates a new account batch with the specified capacity.
+
+  The capacity is the maximum number of accounts that can be added to the batch.
+  """
+  @spec new(filter :: AccountFilter.t()) ::
+          {:ok, t()} | {:error, Types.create_batch_error()} | {:error, Types.append_error()}
+  def new(filter) do
+    binary = AccountFilter.to_batch_item(filter)
+    # 1 is the only valid value here - since that's what tigerbeetle expects
+    # https://docs.tigerbeetle.com/reference/requests/#batching-events
+    with {:ok, ref} <- NifAdapter.create_account_filter_batch(1),
+         :ok <- NifAdapter.append_account_filter(ref, binary) do
+      {:ok, %AccountFilterBatch{ref: ref}}
+    end
+  end
+
+  @doc """
+  Creates a new account batch with the specified capacity, rasing in case of an error.
+  """
+  @spec new!(filter :: AccountFilter.t()) :: t()
+  def new!(capacity) when is_integer(capacity) and capacity > 0 do
+    case new(capacity) do
+      {:ok, batch} -> batch
+      {:error, :out_of_memory} -> raise OutOfMemoryError
+      {:error, :invalid_batch} -> raise InvalidBatchError
+      {:error, :batch_full} -> raise BatchFullError
+    end
+  end
+end

--- a/lib/tigerbeetlex/account_filter_batch.ex
+++ b/lib/tigerbeetlex/account_filter_batch.ex
@@ -11,9 +11,9 @@ defmodule TigerBeetlex.AccountFilterBatch do
 
   alias TigerBeetlex.AccountFilter
   alias TigerBeetlex.AccountFilterBatch
+  alias TigerBeetlex.BatchFullError
   alias TigerBeetlex.InvalidBatchError
   alias TigerBeetlex.NifAdapter
-  alias TigerBeetlex.OutOfBoundsError
   alias TigerBeetlex.OutOfMemoryError
   alias TigerBeetlex.Types
 

--- a/lib/tigerbeetlex/account_filter_batch.ex
+++ b/lib/tigerbeetlex/account_filter_batch.ex
@@ -24,7 +24,7 @@ defmodule TigerBeetlex.AccountFilterBatch do
   """
   @spec new(filter :: AccountFilter.t()) ::
           {:ok, t()} | {:error, Types.create_batch_error()} | {:error, Types.append_error()}
-  def new(filter) do
+  def new(%AccountFilter{} = filter) do
     binary = AccountFilter.to_batch_item(filter)
     # 1 is the only valid value here - since that's what tigerbeetle expects
     # https://docs.tigerbeetle.com/reference/requests/#batching-events
@@ -38,8 +38,8 @@ defmodule TigerBeetlex.AccountFilterBatch do
   Creates a new account batch with the specified capacity, rasing in case of an error.
   """
   @spec new!(filter :: AccountFilter.t()) :: t()
-  def new!(capacity) when is_integer(capacity) and capacity > 0 do
-    case new(capacity) do
+  def new!(%AccountFilter{} = filter) do
+    case new(filter) do
       {:ok, batch} -> batch
       {:error, :out_of_memory} -> raise OutOfMemoryError
       {:error, :invalid_batch} -> raise InvalidBatchError

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -10,8 +10,8 @@ defmodule TigerBeetlex.Connection do
   """
 
   alias TigerBeetlex.{
-    AccountFilterBatch,
     AccountBatch,
+    AccountFilterBatch,
     IDBatch,
     Receiver,
     TransferBatch,

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -10,6 +10,7 @@ defmodule TigerBeetlex.Connection do
   """
 
   alias TigerBeetlex.{
+    AccountFilterBatch,
     AccountBatch,
     IDBatch,
     Receiver,
@@ -286,6 +287,16 @@ defmodule TigerBeetlex.Connection do
   def lookup_transfers(name, %IDBatch{} = id_batch) do
     via_tuple(name)
     |> GenServer.call({:lookup_transfers, id_batch})
+  end
+
+  def get_account_balances(name, %AccountFilterBatch{} = batch) do
+    via_tuple(name)
+    |> GenServer.call({:get_account_balances, batch})
+  end
+
+  def get_account_transfers(name, %AccountFilterBatch{} = batch) do
+    via_tuple(name)
+    |> GenServer.call({:get_account_transfers, batch})
   end
 
   defp via_tuple(name) do

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -51,6 +51,29 @@ defmodule TigerBeetlex.NifAdapter do
           {:ok, Types.transfer_batch()} | {:error, Types.create_batch_error()}
   def create_transfer_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
 
+  @spec create_transfer_batch(capacity :: non_neg_integer()) ::
+          {:ok, Types.transfer_batch()} | {:error, Types.create_batch_error()}
+  def create_transfer_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec get_account_transfers(client :: Types.client(), batch :: Types.account_filter_batch()) ::
+          {:ok, reference()} | {:error, Types.lookup_transfers_error()}
+  def get_account_transfers(_client, _id), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec get_account_balances(client :: Types.client(), batch :: Types.account_filter_batch()) ::
+          {:ok, reference()} | {:error, Types.lookup_accounts_error()}
+  def get_account_balances(_client, _id), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec create_account_filter_batch(capacity :: non_neg_integer()) ::
+          {:ok, Types.account_filter_batch()} | {:error, Types.create_batch_error()} 
+  def create_account_filter_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec append_account_filter(
+          batch :: Types.account_filter_batch(),
+          binary :: Types.account_filter_binary()
+  ) ::
+          {:ok, Types.account_filter_batch()} | {:error, Types.append_batch_error()} 
+  def append_account_filter(_batch, _binary), do: :erlang.nif_error(:nif_not_loaded)
+
   @spec append_transfer(
           transfer_batch :: Types.transfer_batch(),
           transfer_binary :: Types.transfer_binary()

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -64,14 +64,14 @@ defmodule TigerBeetlex.NifAdapter do
   def get_account_balances(_client, _id), do: :erlang.nif_error(:nif_not_loaded)
 
   @spec create_account_filter_batch(capacity :: non_neg_integer()) ::
-          {:ok, Types.account_filter_batch()} | {:error, Types.create_batch_error()} 
+          {:ok, Types.account_filter_batch()} | {:error, Types.create_batch_error()}
   def create_account_filter_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
 
   @spec append_account_filter(
           batch :: Types.account_filter_batch(),
           binary :: Types.account_filter_binary()
-  ) ::
-          {:ok, Types.account_filter_batch()} | {:error, Types.append_batch_error()} 
+        ) ::
+          {:ok, Types.account_filter_batch()} | {:error, Types.append_batch_error()}
   def append_account_filter(_batch, _binary), do: :erlang.nif_error(:nif_not_loaded)
 
   @spec append_transfer(

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -51,10 +51,6 @@ defmodule TigerBeetlex.NifAdapter do
           {:ok, Types.transfer_batch()} | {:error, Types.create_batch_error()}
   def create_transfer_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
 
-  @spec create_transfer_batch(capacity :: non_neg_integer()) ::
-          {:ok, Types.transfer_batch()} | {:error, Types.create_batch_error()}
-  def create_transfer_batch(_capacity), do: :erlang.nif_error(:nif_not_loaded)
-
   @spec get_account_transfers(client :: Types.client(), batch :: Types.account_filter_batch()) ::
           {:ok, reference()} | {:error, Types.lookup_transfers_error()}
   def get_account_transfers(_client, _id), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/tigerbeetlex/receiver.ex
+++ b/lib/tigerbeetlex/receiver.ex
@@ -37,6 +37,14 @@ defmodule TigerBeetlex.Receiver do
     send_request(from, :lookup_transfers, [state.client, id_batch], state)
   end
 
+  def handle_call({:get_account_balances, id_batch}, from, state) do
+    send_request(from, :get_account_balances, [state.client, id_batch], state)
+  end
+
+  def handle_call({:get_account_transfers, id_batch}, from, state) do
+    send_request(from, :get_account_transfers, [state.client, id_batch], state)
+  end
+
   defp send_request(from, function, arguments, state) do
     case apply(TigerBeetlex, function, arguments) do
       {:ok, ref} ->

--- a/lib/tigerbeetlex/response.ex
+++ b/lib/tigerbeetlex/response.ex
@@ -10,6 +10,7 @@ defmodule TigerBeetlex.Response do
 
   alias TigerBeetlex.{
     Account,
+    AccountBalance,
     CreateAccountError,
     CreateTransferError,
     PacketStatus,
@@ -23,17 +24,24 @@ defmodule TigerBeetlex.Response do
   @type operation_create_transfers :: 130
   @type operation_lookup_accounts :: 131
   @type operation_lookup_transfers :: 132
+  @type operation_get_account_transfers :: 133
+  @type operation_get_account_balances :: 134
 
   @type operation ::
           operation_create_accounts()
           | operation_create_transfers()
           | operation_lookup_accounts()
           | operation_lookup_transfers()
+          | operation_get_account_transfers()
+          | operation_get_account_balances()
 
   @operation_create_accounts 129
   @operation_create_transfers 130
   @operation_lookup_accounts 131
   @operation_lookup_transfers 132
+  @operation_get_account_transfers 133
+  @operation_get_account_balances 134
+
 
   typedstruct opaque: true do
     field :operation, non_neg_integer()
@@ -52,6 +60,8 @@ defmodule TigerBeetlex.Response do
   - `operation_create_transfer`: a stream of `%TigerBeetlex.CreateTransferError{}`.
   - `operation_lookup_accounts`: a stream of `%TigerBeetlex.Account{}`.
   - `operation_lookup_transfers`: a stream of `%TigerBeetlex.Transfer{}`.
+  - `operation_get_account_transfers`: a stream of `%TigerBeetlex.Transfer{}`.
+  - `operation_get_account_balances`: a stream of `%TigerBeetlex.AccountBalance{}`.
   """
   @spec to_stream(response :: {status :: status(), operation :: operation(), data :: binary()}) ::
           {:ok, Enumerable.t()} | {:error, reason :: atom()}
@@ -94,6 +104,20 @@ defmodule TigerBeetlex.Response do
     fn
       <<>> -> nil
       <<transfer::binary-size(128), rest::binary>> -> {Transfer.from_binary(transfer), rest}
+    end
+  end
+
+  defp unfold_function(@operation_get_account_transfers) do
+    fn
+      <<>> -> nil
+      <<transfer::binary-size(128), rest::binary>> -> {Transfer.from_binary(transfer), rest}
+    end
+  end
+
+  defp unfold_function(@operation_get_account_balances) do
+    fn
+      <<>> -> nil
+      <<transfer::binary-size(128), rest::binary>> -> {AccountBalance.from_binary(transfer), rest}
     end
   end
 end

--- a/lib/tigerbeetlex/response.ex
+++ b/lib/tigerbeetlex/response.ex
@@ -42,7 +42,6 @@ defmodule TigerBeetlex.Response do
   @operation_get_account_transfers 133
   @operation_get_account_balances 134
 
-
   typedstruct opaque: true do
     field :operation, non_neg_integer()
     field :data, binary()

--- a/src/account_filter_batch.zig
+++ b/src/account_filter_batch.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const assert = std.debug.assert;
+
+const batch = @import("batch.zig");
+const beam = @import("beam.zig");
+const scheduler = beam.scheduler;
+
+const tb = @import("tigerbeetle/src/tigerbeetle.zig");
+const AccountFilter = tb.AccountFilter;
+pub const AccountFilterBatch = batch.Batch(AccountFilter);
+pub const AccountFilterBatchResource = batch.BatchResource(AccountFilter);
+
+pub fn create(env: beam.Env, capacity: u32) beam.Term {
+    return batch.create(AccountFilter, env, capacity) catch |err| switch (err) {
+        error.OutOfMemory => return beam.make_error_atom(env, "out_of_memory"),
+    };
+}
+
+pub fn append(
+    env: beam.Env,
+    transfer_batch_resource: AccountFilterBatchResource,
+    transfer_bytes: []const u8,
+) !beam.Term {
+    if (transfer_bytes.len != @sizeOf(AccountFilter)) return beam.raise_badarg(env);
+
+    return batch.append(
+        AccountFilter,
+        env,
+        transfer_batch_resource,
+        transfer_bytes,
+    ) catch |err| switch (err) {
+        error.BatchFull => beam.make_error_atom(env, "batch_full"),
+        error.LockFailed => return error.Yield,
+    };
+}

--- a/src/client.zig
+++ b/src/client.zig
@@ -8,6 +8,7 @@ const Resource = resource.Resource;
 
 const tb = @import("tigerbeetle/src/tigerbeetle.zig");
 const tb_client = @import("tigerbeetle/src/clients/c/tb_client.zig");
+const AccountFilter = tb.AccountFilter;
 const Account = tb.Account;
 const Transfer = tb.Transfer;
 
@@ -61,7 +62,8 @@ fn OperationBatchItemType(comptime operation: tb_client.tb_operation_t) type {
         .create_accounts => Account,
         .create_transfers => Transfer,
         .lookup_accounts, .lookup_transfers => u128,
-        .get_account_transfers, .get_account_balances, .query_accounts, .query_transfers => @panic("TODO"),
+        .get_account_transfers, .get_account_balances => AccountFilter,
+        .query_accounts, .query_transfers => @panic("TODO"),
         .pulse => unreachable,
     };
 }
@@ -77,6 +79,8 @@ pub const create_accounts = get_submit_fn(.create_accounts);
 pub const create_transfers = get_submit_fn(.create_transfers);
 pub const lookup_accounts = get_submit_fn(.lookup_accounts);
 pub const lookup_transfers = get_submit_fn(.lookup_transfers);
+pub const get_account_transfers = get_submit_fn(.get_account_transfers);
+pub const get_account_balances = get_submit_fn(.get_account_balances);
 
 fn get_submit_fn(comptime operation: tb_client.tb_operation_t) (fn (
     env: beam.Env,

--- a/src/client.zig
+++ b/src/client.zig
@@ -161,10 +161,12 @@ fn on_completion(
     context: usize,
     client: tb_client.tb_client_t,
     packet: *tb_client.tb_packet_t,
+    timestamp: u64,
     result_ptr: ?[*]const u8,
     result_len: u32,
 ) callconv(.C) void {
     _ = client;
+    _ = timestamp;
     const ctx: *RequestContext = @ptrCast(@alignCast(packet.user_data.?));
     defer beam.general_purpose_allocator.destroy(ctx);
 

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -18,15 +18,12 @@ const IdBatchResource = id_batch.IdBatchResource;
 const TransferBatchResource = transfer_batch.TransferBatchResource;
 
 pub const vsr_options = .{
-    .config_base = .default,
-    .config_log_level = std.log.Level.info,
-    .tracer_backend = .none,
+    .config_verify = true,
     .hash_log_mode = .none,
     .git_commit = null,
     // TODO: take these from a proper place
-    .release = "0.15.4",
-    .release_client_min = "0.15.4",
-    .config_aof_record = false,
+    .release = "0.16.18",
+    .release_client_min = "0.16.18",
     .config_aof_recovery = false,
 };
 

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -26,7 +26,7 @@ pub const vsr_options = .{
     .git_commit = null,
     // TODO: take these from a proper place
     .release = "0.16.18",
-    .release_client_min = "0.16.18",
+    .release_client_min = "0.15.4",
     .config_aof_recovery = false,
 };
 

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -7,15 +7,18 @@ const account_batch = @import("account_batch.zig");
 const client = @import("client.zig");
 const id_batch = @import("id_batch.zig");
 const transfer_batch = @import("transfer_batch.zig");
+const account_filter_batch = @import("account_filter_batch.zig");
 const AccountBatch = account_batch.AccountBatch;
 const IdBatch = id_batch.IdBatch;
 const TransferBatch = transfer_batch.TransferBatch;
+const AccountFilterBatch = account_filter_batch.TransferBatch;
 const Client = client.Client;
 
 const ClientResource = client.ClientResource;
 const AccountBatchResource = account_batch.AccountBatchResource;
 const IdBatchResource = id_batch.IdBatchResource;
 const TransferBatchResource = transfer_batch.TransferBatchResource;
+const AccountFilterBatchResource = account_filter_batch.AccountFilterBatchResource;
 
 pub const vsr_options = .{
     .config_verify = true,
@@ -37,6 +40,10 @@ var exported_nifs = [_]nif.FunctionEntry{
     nif.wrap("create_transfers", client.create_transfers),
     nif.wrap("lookup_accounts", client.lookup_accounts),
     nif.wrap("lookup_transfers", client.lookup_transfers),
+    nif.wrap("get_account_balances", client.get_account_balances),
+    nif.wrap("get_account_transfers", client.get_account_transfers),
+    nif.wrap("create_account_filter_batch", account_filter_batch.create),
+    nif.wrap("append_account_filter", account_filter_batch.append),
     nif.wrap("create_account_batch", account_batch.create),
     nif.wrap("append_account", account_batch.append),
     nif.wrap("fetch_account", account_batch.fetch),
@@ -56,6 +63,7 @@ fn nif_load(env: beam.Env, _: [*c]?*anyopaque, _: beam.Term) callconv(.C) c_int 
     AccountBatchResource.create_type(env, "TigerBeetlex.AccountBatch");
     IdBatchResource.create_type(env, "TigerBeetlex.IdBatch");
     TransferBatchResource.create_type(env, "TigerBeetlex.TransferBatch");
+    AccountFilterBatchResource.create_type(env, "TigerBeetlex.AccountFilterBatch");
     return 0;
 }
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -148,13 +148,13 @@ defmodule TigerBeetlex.IntegrationTest do
              } = get_account!(conn, credit_account_id)
 
       assert [
-               %TigerBeetlex.AccountBalance{
+               %AccountBalance{
                  debits_pending: 0,
                  debits_posted: 100,
                  credits_pending: 0,
                  credits_posted: 0
                },
-               %TigerBeetlex.AccountBalance{
+               %AccountBalance{
                  debits_pending: 0,
                  debits_posted: 3100,
                  credits_pending: 0,
@@ -163,13 +163,13 @@ defmodule TigerBeetlex.IntegrationTest do
              ] = get_balances!(conn, debit_account_id)
 
       assert [
-               %TigerBeetlex.AccountBalance{
+               %AccountBalance{
                  debits_pending: 0,
                  debits_posted: 0,
                  credits_pending: 0,
                  credits_posted: 100
                },
-               %TigerBeetlex.AccountBalance{
+               %AccountBalance{
                  debits_pending: 0,
                  debits_posted: 0,
                  credits_pending: 0,
@@ -256,19 +256,19 @@ defmodule TigerBeetlex.IntegrationTest do
              } = get_account!(conn, credit_account_id)
 
       assert [
-               %TigerBeetlex.Transfer{
+               %Transfer{
                  amount: 100
                },
-               %TigerBeetlex.Transfer{
+               %Transfer{
                  amount: 3000
                }
              ] = get_account_transfers!(conn, debit_account_id)
 
       assert [
-               %TigerBeetlex.Transfer{
+               %Transfer{
                  amount: 100
                },
-               %TigerBeetlex.Transfer{
+               %Transfer{
                  amount: 3000
                }
              ] = get_account_transfers!(conn, credit_account_id)
@@ -1124,7 +1124,7 @@ defmodule TigerBeetlex.IntegrationTest do
     {:ok, batch} =
       AccountFilterBatch.new(%AccountFilter{
         account_id: account_id,
-        flags: %TigerBeetlex.AccountFilter.Flags{debits: true, credits: true}
+        flags: %AccountFilter.Flags{debits: true, credits: true}
       })
 
     {:ok, stream} = Connection.get_account_balances(conn, batch)
@@ -1135,7 +1135,7 @@ defmodule TigerBeetlex.IntegrationTest do
     {:ok, batch} =
       AccountFilterBatch.new(%AccountFilter{
         account_id: account_id,
-        flags: %TigerBeetlex.AccountFilter.Flags{debits: true, credits: true}
+        flags: %AccountFilter.Flags{debits: true, credits: true}
       })
 
     {:ok, stream} = Connection.get_account_transfers(conn, batch)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -256,32 +256,20 @@ defmodule TigerBeetlex.IntegrationTest do
              } = get_account!(conn, credit_account_id)
 
       assert [
-               %TigerBeetlex.AccountBalance{
-                 debits_pending: 0,
-                 debits_posted: 100,
-                 credits_pending: 0,
-                 credits_posted: 0
+               %TigerBeetlex.Transfer{
+                 amount: 100
                },
-               %TigerBeetlex.AccountBalance{
-                 debits_pending: 0,
-                 debits_posted: 3100,
-                 credits_pending: 0,
-                 credits_posted: 0
+               %TigerBeetlex.Transfer{
+                 amount: 3000
                }
              ] = get_account_transfers!(conn, debit_account_id)
 
       assert [
-               %TigerBeetlex.AccountBalance{
-                 debits_pending: 0,
-                 debits_posted: 0,
-                 credits_pending: 0,
-                 credits_posted: 100
+               %TigerBeetlex.Transfer{
+                 amount: 100
                },
-               %TigerBeetlex.AccountBalance{
-                 debits_pending: 0,
-                 debits_posted: 0,
-                 credits_pending: 0,
-                 credits_posted: 3100
+               %TigerBeetlex.Transfer{
+                 amount: 3000
                }
              ] = get_account_transfers!(conn, credit_account_id)
     end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -406,7 +406,8 @@ defmodule TigerBeetlex.IntegrationTest do
       post_pending_transfer = %Transfer{
         id: post_pending_id,
         pending_id: pending_id,
-        flags: %Transfer.Flags{post_pending_transfer: true}
+        flags: %Transfer.Flags{post_pending_transfer: true},
+        amount: 100
       }
 
       {:ok, batch} = TransferBatch.append(batch, post_pending_transfer)
@@ -425,12 +426,24 @@ defmodule TigerBeetlex.IntegrationTest do
                flags: %Transfer.Flags{post_pending_transfer: true}
              } = get_transfer!(conn, post_pending_id)
 
+      assert %Transfer{
+               id: ^pending_id,
+               credit_account_id: ^credit_account_id,
+               debit_account_id: ^debit_account_id,
+               ledger: 1,
+               code: 1,
+               amount: 100,
+               flags: %Transfer.Flags{pending: true}
+             } = get_transfer!(conn, pending_id)
+
       assert %Account{
                id: ^credit_account_id,
                ledger: 1,
                code: 1,
                credits_pending: 0,
-               credits_posted: 100
+               credits_posted: 100,
+               debits_pending: 0,
+               debits_posted: 0
              } = get_account!(conn, credit_account_id)
 
       assert %Account{

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -35,6 +35,35 @@ defmodule TigerBeetlex.IntegrationTest do
       {:ok, batch: batch}
     end
 
+    test "we can get account balances", ctx do
+      %{
+        batch: batch,
+        conn: conn,
+      } = ctx
+
+      id = random_id()
+
+      account = %Account{
+        id: id,
+        ledger: 1,
+        code: 1,
+        flags: %Account.Flags{history: true}
+      }
+
+      {:ok, batch} = AccountBatch.append(batch, account)
+
+      assert {:ok, stream} = Connection.create_accounts(conn, batch)
+      assert [] == Enum.to_list(stream)
+
+      assert %Account{
+               id: ^id,
+               ledger: 1,
+               code: 1,
+               flags: %Account.Flags{history: true}
+             } = get_account!(conn, id)
+    end
+
+
     test "successful account creation", %{conn: conn, batch: batch} do
       id = random_id()
 
@@ -823,6 +852,7 @@ defmodule TigerBeetlex.IntegrationTest do
       assert {:ok, stream} = Connection.lookup_transfers(conn, batch)
       assert [%Transfer{id: ^transfer_id}] = Enum.to_list(stream)
     end
+
   end
 
   defp random_id do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -271,19 +271,18 @@ defmodule TigerBeetlex.IntegrationTest do
              ] = get_account_transfers!(conn, debit_account_id)
 
       assert [
-                             %TigerBeetlex.AccountBalance{
-                debits_pending: 0,
-                debits_posted: 0,
-                credits_pending: 0,
-                credits_posted: 100
-              },
-              %TigerBeetlex.AccountBalance{
-                debits_pending: 0,
-                debits_posted: 0,
-                credits_pending: 0,
-                credits_posted: 3100
-              }
-
+               %TigerBeetlex.AccountBalance{
+                 debits_pending: 0,
+                 debits_posted: 0,
+                 credits_pending: 0,
+                 credits_posted: 100
+               },
+               %TigerBeetlex.AccountBalance{
+                 debits_pending: 0,
+                 debits_posted: 0,
+                 credits_pending: 0,
+                 credits_posted: 3100
+               }
              ] = get_account_transfers!(conn, credit_account_id)
     end
   end


### PR DESCRIPTION
I wanted to support account history - but it was lacking. So I added it to the client.

I tried to navigate my way around the NIF but I might have missed a `spec` in the elixir code somewhere since I don't verify them locally.

I know I have some examples left to write - but since I don't know if this is getting merged I waited on adding them. :)

All suggestions welcome - though I might not apply them they are appreciated non-the-less.