### PR TITLE
feat: add support for `query_accounts` and `query_transfers`

### DIFF
--- a/lib/tigerbeetlex.ex
+++ b/lib/tigerbeetlex.ex
@@ -193,7 +193,7 @@ defmodule TigerBeetlex do
 
   `client` is a `%TigerBeetlex{}` client.
 
-  `account_filter` is a `TigerBeetlex.AccountFilter` struct.
+  `account_filter` is a `TigerBeetlex.AccountFilter` struct. The `limit` field must be set.
 
   The function returns a ref which can be used to match the received response message.
 
@@ -213,7 +213,7 @@ defmodule TigerBeetlex do
   ## Examples
       alias TigerBeetlex.AccountFilter
 
-      account_filter = %AccountFilter{id: <<42::128>>}
+      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
 
       {:ok, ref} = TigerBeetlex.get_account_balances(client, account_filter)
 
@@ -236,7 +236,7 @@ defmodule TigerBeetlex do
 
   `client` is a `%TigerBeetlex{}` client.
 
-  `account_filter` is a `TigerBeetlex.AccountFilter` struct.
+  `account_filter` is a `TigerBeetlex.AccountFilter` struct. The `limit` field must be set.
 
   The function returns a ref which can be used to match the received response message.
 
@@ -256,7 +256,7 @@ defmodule TigerBeetlex do
   ## Examples
       alias TigerBeetlex.AccountFilter
 
-      account_filter = %AccountFilter{id: <<42::128>>}
+      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
 
       {:ok, ref} = TigerBeetlex.get_account_balances(client, account_filter)
 

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -279,7 +279,7 @@ defmodule TigerBeetlex.Connection do
 
   `name` is the same atom that was passed in the `:name` option in `start_link/1`.
 
-  `account_filter` is a `TigerBeetlex.AccountFilter` struct.
+  `account_filter` is a `TigerBeetlex.AccountFilter` struct. The `limit` field must be set.
 
   If successful, the function returns `{:ok, results}` where `results` is a list of
   `TigerBeetlex.AccountBalance` structs.
@@ -289,7 +289,7 @@ defmodule TigerBeetlex.Connection do
   ## Examples
       alias TigerBeetlex.AccountFilter
 
-      account_filter = %AccountFilter{id: <<42::128>>}
+      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
 
       TigerBeetlex.Connection.get_account_balances(:tb, account_filter)
       #=> {:ok, [%TigerBeetlex.AccountBalance{}]}
@@ -309,7 +309,7 @@ defmodule TigerBeetlex.Connection do
 
   `name` is the same atom that was passed in the `:name` option in `start_link/1`.
 
-  `account_filter` is a `TigerBeetlex.AccountFilter` struct.
+  `account_filter` is a `TigerBeetlex.AccountFilter` struct. The `limit` field must be set.
 
   If successful, the function returns `{:ok, results}` where `results` is a list of
   `TigerBeetlex.Transfer` structs.
@@ -319,7 +319,7 @@ defmodule TigerBeetlex.Connection do
   ## Examples
       alias TigerBeetlex.AccountFilter
 
-      account_filter = %AccountFilter{id: <<42::128>>}
+      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
 
       TigerBeetlex.Connection.get_account_transfers(:tb, account_filter)
       #=> {:ok, [%TigerBeetlex.Transfer{}]}

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -14,6 +14,7 @@ defmodule TigerBeetlex.Connection do
   alias TigerBeetlex.AccountFilter
   alias TigerBeetlex.CreateAccountsResult
   alias TigerBeetlex.CreateTransfersResult
+  alias TigerBeetlex.QueryFilter
   alias TigerBeetlex.Receiver
   alias TigerBeetlex.Transfer
   alias TigerBeetlex.Types
@@ -332,6 +333,66 @@ defmodule TigerBeetlex.Connection do
   def get_account_transfers(name, %AccountFilter{} = account_filter) do
     via_tuple(name)
     |> GenServer.call({:get_account_transfers, account_filter})
+  end
+
+  @doc """
+  Query accounts by the intersection of some fields and by timestamp range.
+
+  `name` is the same atom that was passed in the `:name` option in `start_link/1`.
+
+  `query_filter` is a `TigerBeetlex.QueryFilter` struct. The `limit` field must be set.
+
+  If successful, the function returns `{:ok, results}` where `results` is a list of
+  `TigerBeetlex.Account` structs.
+
+  See [`query_accounts`](https://docs.tigerbeetle.com/reference/requests/query_accounts/).
+
+  ## Examples
+      alias TigerBeetlex.QueryFilter
+
+      query_filter = %QueryFilter{id: <<42::128>>, limit: 10}
+
+      TigerBeetlex.Connection.query_accounts(:tb, query_filter)
+      #=> {:ok, [%TigerBeetlex.Account{}]}
+  """
+  @spec query_accounts(
+          name :: PartitionSupervisor.name(),
+          query_filter :: QueryFilter.t()
+        ) ::
+          {:ok, [Account.t()]} | {:error, Types.request_error()}
+  def query_accounts(name, %QueryFilter{} = query_filter) do
+    via_tuple(name)
+    |> GenServer.call({:query_accounts, query_filter})
+  end
+
+  @doc """
+  Query transfers by the intersection of some fields and by timestamp range.
+
+  `name` is the same atom that was passed in the `:name` option in `start_link/1`.
+
+  `query_filter` is a `TigerBeetlex.QueryFilter` struct. The `limit` field must be set.
+
+  If successful, the function returns `{:ok, results}` where `results` is a list of
+  `TigerBeetlex.Transfer` structs.
+
+  See [`query_transfers`](https://docs.tigerbeetle.com/reference/requests/query_transfers/).
+
+  ## Examples
+      alias TigerBeetlex.QueryFilter
+
+      query_filter = %QueryFilter{id: <<42::128>>, limit: 10}
+
+      TigerBeetlex.Connection.query_transfers(:tb, query_filter)
+      #=> {:ok, [%TigerBeetlex.Transfer{}]}
+  """
+  @spec query_transfers(
+          name :: PartitionSupervisor.name(),
+          query_filter :: QueryFilter.t()
+        ) ::
+          {:ok, [Account.t()]} | {:error, Types.request_error()}
+  def query_transfers(name, %QueryFilter{} = query_filter) do
+    via_tuple(name)
+    |> GenServer.call({:query_transfers, query_filter})
   end
 
   defp via_tuple(name) do

--- a/lib/tigerbeetlex/nif_adapter.ex
+++ b/lib/tigerbeetlex/nif_adapter.ex
@@ -43,4 +43,12 @@ defmodule TigerBeetlex.NifAdapter do
   @spec lookup_transfers(client :: Types.client(), payload :: binary()) ::
           {:ok, reference()} | {:error, Types.request_error()}
   def lookup_transfers(_client, _id_batch), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec query_accounts(client :: Types.client(), payload :: binary()) ::
+          {:ok, reference()} | {:error, Types.request_error()}
+  def query_accounts(_client, _id_batch), do: :erlang.nif_error(:nif_not_loaded)
+
+  @spec query_transfers(client :: Types.client(), payload :: binary()) ::
+          {:ok, reference()} | {:error, Types.request_error()}
+  def query_transfers(_client, _id_batch), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/tigerbeetlex/receiver.ex
+++ b/lib/tigerbeetlex/receiver.ex
@@ -45,6 +45,14 @@ defmodule TigerBeetlex.Receiver do
     send_request(from, :get_account_transfers, [state.client, account_filter], state)
   end
 
+  def handle_call({:query_accounts, query_filter}, from, state) do
+    send_request(from, :query_accounts, [state.client, query_filter], state)
+  end
+
+  def handle_call({:query_transfers, query_filter}, from, state) do
+    send_request(from, :query_transfers, [state.client, query_filter], state)
+  end
+
   defp send_request(from, function, arguments, state) do
     case apply(TigerBeetlex, function, arguments) do
       {:ok, ref} ->

--- a/src/client.zig
+++ b/src/client.zig
@@ -130,6 +130,24 @@ pub fn get_account_balances(env: beam.Env, client_resource: beam.Term, payload_t
     ) catch |err| handle_submit_error(env, err);
 }
 
+pub fn query_accounts(env: beam.Env, client_resource: beam.Term, payload_term: beam.Term) beam.Term {
+    return submit(
+        env,
+        client_resource,
+        .query_accounts,
+        payload_term,
+    ) catch |err| handle_submit_error(env, err);
+}
+
+pub fn query_transfers(env: beam.Env, client_resource: beam.Term, payload_term: beam.Term) beam.Term {
+    return submit(
+        env,
+        client_resource,
+        .query_transfers,
+        payload_term,
+    ) catch |err| handle_submit_error(env, err);
+}
+
 fn submit(
     env: beam.Env,
     client_term: beam.Term,

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -22,6 +22,8 @@ var exported_nifs = [_]nif.FunctionEntry{
     nif.wrap("lookup_transfers", client.lookup_transfers),
     nif.wrap("get_account_balances", client.get_account_balances),
     nif.wrap("get_account_transfers", client.get_account_transfers),
+    nif.wrap("query_accounts", client.query_accounts),
+    nif.wrap("query_transfers", client.query_transfers),
 };
 
 fn nif_load(env: beam.Env, _: [*c]?*anyopaque, _: beam.Term) callconv(.C) c_int {


### PR DESCRIPTION
Allow querying accounts and transfers using QueryFilter

Supersedes #53 