### PR TITLE
chore: update TigerBeetle to 0.16.38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           version: ${{ matrix.zig }}
 
       - name: Install and compile dependencies
-        run: mix do deps.get --only test, deps.compile
+        run: mix do deps.get, deps.compile
 
       - name: Check Elixir formatting
         run: mix format --check-formatted
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-plt
         with:
-          path: priv/plts
+          path: _build
           key: ${{ runner.os }}-otp${{ matrix.otp }}-elixir${{ matrix.elixir }}
 
       # Create PLTs if no cache was found

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,8 +24,8 @@
     // internet connectivity.
     .dependencies = .{
         .tigerbeetle = .{
-            .url = "https://github.com/tigerbeetle/tigerbeetle/archive/refs/tags/0.16.36.tar.gz",
-            .hash = "122004a3bf1aa78e0d27a6c7d37b52818bab1af3daa44c744880744eea8169a5977a",
+            .url = "https://github.com/tigerbeetle/tigerbeetle/archive/refs/tags/0.16.38.tar.gz",
+            .hash = "12209748ae21d58b4c295c19083ca41e1add631ad684d1be83a840221d2bb62534de",
         },
     },
     .paths = .{

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,6 @@ defmodule TigerBeetlex.MixProject do
       zig_build_mode: zig_build_mode(Mix.env()),
       compilers: [:build_dot_zig] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
-      dialyzer: [plt_add_apps: [:zig_parser]],
       deps: deps()
     ]
   end

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,5 +1,5 @@
 pub const vsr_options = .{
-    .release = "0.16.36",
+    .release = "0.16.38",
     .release_client_min = "0.16.4",
     .git_commit = null,
     .hash_log_mode = .none,

--- a/src/tigerbeetlex.zig
+++ b/src/tigerbeetlex.zig
@@ -58,7 +58,7 @@ fn init_client(env: *beam.Env, cluster_id_term: beam.Term, addresses_term: beam.
     errdefer beam.general_purpose_allocator.destroy(client);
 
     try tb_client.init(
-        beam.general_purpose_allocator,
+        beam.large_allocator,
         client,
         cluster_id,
         addresses,


### PR DESCRIPTION
Since the client now wraps the provided allocator in a GPA, pass the underlying large_beam_allocator