### PR TITLE
feat: add TigerBeetlex.ID.from_int/1

### DIFF
--- a/bench/benchmark.exs
+++ b/bench/benchmark.exs
@@ -1,10 +1,11 @@
 alias TigerBeetlex.Connection
+alias TigerBeetlex.ID
 alias TigerBeetlex.Transfer
 
 {:ok, _pid} =
   Connection.start_link(
     name: :tb,
-    cluster_id: <<0::128>>,
+    cluster_id: ID.from_int(0),
     addresses: ["3000"],
     partitions: 1
   )
@@ -27,9 +28,9 @@ bench = fn ->
       transfers =
         for _idx <- chunk do
           %Transfer{
-            id: <<0::unsigned-little-size(128)>>,
-            debit_account_id: <<0::unsigned-little-size(128)>>,
-            credit_account_id: <<0::unsigned-little-size(128)>>,
+            id: ID.from_int(0),
+            debit_account_id: ID.from_int(0),
+            credit_account_id: ID.from_int(0),
             ledger: 1,
             code: 1,
             amount: 10

--- a/lib/tigerbeetlex/client.ex
+++ b/lib/tigerbeetlex/client.ex
@@ -73,7 +73,9 @@ defmodule TigerBeetlex.Client do
 
   ## Examples
 
-      {:ok, client} = Client.new(<<0::128>>, ["3000"])
+      alias TigerBeetlex.ID
+
+      {:ok, client} = Client.new(ID.from_int(0), ["3000"])
   """
   @spec new(
           cluster_id :: Types.id_128(),
@@ -116,7 +118,7 @@ defmodule TigerBeetlex.Client do
       #=> {:ok, []}
 
       # Creation error
-      accounts = [%Account{id: <<0::128>>, ledger: 3, code: 4}]
+      accounts = [%Account{id: ID.from_int(0), ledger: 3, code: 4}]
 
       {:ok, ref} = Client.create_accounts(client, accounts)
 
@@ -154,8 +156,8 @@ defmodule TigerBeetlex.Client do
       transfers = [
         %Transfer{
           id: ID.generate(),
-          debit_account_id: <<42::128>>,
-          credit_account_id: <<43::128>>,
+          debit_account_id: ID.from_int(42),
+          credit_account_id: ID.from_int(43),
           ledger: 3,
           code: 4
           amount: 100
@@ -171,9 +173,9 @@ defmodule TigerBeetlex.Client do
       # Creation error
       transfers = [
         %Transfer{
-          id: <<0::128>>,
-          debit_account_id: <<42::128>>,
-          credit_account_id: <<43::128>>,
+          id: ID.from_int(0),
+          debit_account_id: ID.from_int(42),
+          credit_account_id: ID.from_int(43),
           ledger: 3,
           code: 4
           amount: 100
@@ -209,8 +211,9 @@ defmodule TigerBeetlex.Client do
 
   ## Examples
       alias TigerBeetlex.AccountFilter
+      alias TigerBeetlex.ID
 
-      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
+      account_filter = %AccountFilter{id: ID.from_int(42), limit: 10}
 
       {:ok, ref} = Client.get_account_balances(client, account_filter)
 
@@ -239,8 +242,9 @@ defmodule TigerBeetlex.Client do
 
   ## Examples
       alias TigerBeetlex.AccountFilter
+      alias TigerBeetlex.ID
 
-      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
+      account_filter = %AccountFilter{id: ID.from_int(42), limit: 10}
 
       {:ok, ref} = Client.get_account_balances(client, account_filter)
 
@@ -269,7 +273,9 @@ defmodule TigerBeetlex.Client do
 
   ## Examples
 
-      ids = [<<42::128>>]
+      alias TigerBeetlex.ID
+
+      ids = [ID.from_int(42)]
 
       {:ok, ref} = Client.lookup_accounts(client, ids)
 
@@ -297,7 +303,9 @@ defmodule TigerBeetlex.Client do
 
   ## Examples
 
-      ids = [<<42::128>>]
+      alias TigerBeetlex.ID
+
+      ids = [ID.from_int(42)]
 
       {:ok, ref} = Client.lookup_transfers(client, ids)
 
@@ -326,7 +334,7 @@ defmodule TigerBeetlex.Client do
   ## Examples
       alias TigerBeetlex.QueryFilter
 
-      query_filter = %QueryFilter{user_data_128: <<42::128>>, limit: 10}
+      query_filter = %QueryFilter{ledger: 42, limit: 10}
 
       {:ok, ref} = Client.query_accounts(client, query_filter)
 
@@ -356,7 +364,7 @@ defmodule TigerBeetlex.Client do
   ## Examples
       alias TigerBeetlex.QueryFilter
 
-      query_filter = %QueryFilter{user_data_128: <<42::128>>, limit: 10}
+      query_filter = %QueryFilter{ledger: 42, limit: 10}
 
       {:ok, ref} = Client.query_transfers(client, ids)
 

--- a/lib/tigerbeetlex/connection.ex
+++ b/lib/tigerbeetlex/connection.ex
@@ -84,11 +84,13 @@ defmodule TigerBeetlex.Connection do
       )
 
   ## Examples
+      alias TigerBeetlex.Connection
+      alias TigerBeetlex.ID
 
       # Start the TigerBeetlex connection
       {:ok, pid} =
-        TigerBeetlex.Connection.start_link(
-          cluster_id: <<0::128>>,
+        Connection.start_link(
+          cluster_id: ID.from_int(0),
           addresses: ["3000"],
           name: :tb
         )
@@ -139,7 +141,7 @@ defmodule TigerBeetlex.Connection do
       #=> {:ok, []}
 
       # Creation error
-      accounts = [%Account{id: <<0::128>>, ledger: 3, code: 4}]
+      accounts = [%Account{id: ID.from_int(0), ledger: 3, code: 4}]
 
       TigerBeetlex.Connection.create_accounts(:tb, accounts)
 
@@ -177,8 +179,8 @@ defmodule TigerBeetlex.Connection do
       transfers = [
         %Transfer{
           id: ID.generate(),
-          debit_account_id: <<42::128>>,
-          credit_account_id: <<43::128>>,
+          debit_account_id: ID.from_int(42),
+          credit_account_id: ID.from_int(43),
           ledger: 3,
           code: 4
           amount: 100
@@ -191,9 +193,9 @@ defmodule TigerBeetlex.Connection do
       # Creation error
       transfers = [
         %Transfer{
-          id: <<0::128>>,
-          debit_account_id: <<42::128>>,
-          credit_account_id: <<43::128>>,
+          id: ID.from_int(0),
+          debit_account_id: ID.from_int(42),
+          credit_account_id: ID.from_int(43),
           ledger: 3,
           code: 4
           amount: 100
@@ -228,7 +230,9 @@ defmodule TigerBeetlex.Connection do
 
   ## Examples
 
-      ids = [<<42::128>>]
+      alias TigerBeetlex.ID
+
+      ids = [ID.from_int(42)]
 
       TigerBeetlex.Connection.lookup_accounts(:tb, ids)
       #=> {:ok, [%TigerBeetlex.Account{}]}
@@ -258,7 +262,9 @@ defmodule TigerBeetlex.Connection do
 
   ## Examples
 
-      ids = [<<42::128>>]
+      alias TigerBeetlex.ID
+
+      ids = [ID.from_int(43)]
 
       TigerBeetlex.Connection.lookup_transfers(:tb, ids)
       #=> {:ok, [%TigerBeetlex.Transfer{}]}
@@ -288,8 +294,9 @@ defmodule TigerBeetlex.Connection do
 
   ## Examples
       alias TigerBeetlex.AccountFilter
+      alias TigerBeetlex.ID
 
-      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
+      account_filter = %AccountFilter{id: ID.from_int(42), limit: 10}
 
       TigerBeetlex.Connection.get_account_balances(:tb, account_filter)
       #=> {:ok, [%TigerBeetlex.AccountBalance{}]}
@@ -317,8 +324,9 @@ defmodule TigerBeetlex.Connection do
 
   ## Examples
       alias TigerBeetlex.AccountFilter
+      alias TigerBeetlex.ID
 
-      account_filter = %AccountFilter{id: <<42::128>>, limit: 10}
+      account_filter = %AccountFilter{id: ID.from_int(42), limit: 10}
 
       TigerBeetlex.Connection.get_account_transfers(:tb, account_filter)
       #=> {:ok, [%TigerBeetlex.Transfer{}]}
@@ -347,7 +355,7 @@ defmodule TigerBeetlex.Connection do
   ## Examples
       alias TigerBeetlex.QueryFilter
 
-      query_filter = %QueryFilter{id: <<42::128>>, limit: 10}
+      query_filter = %QueryFilter{ledger: 42, limit: 10}
 
       TigerBeetlex.Connection.query_accounts(:tb, query_filter)
       #=> {:ok, [%TigerBeetlex.Account{}]}
@@ -376,7 +384,7 @@ defmodule TigerBeetlex.Connection do
   ## Examples
       alias TigerBeetlex.QueryFilter
 
-      query_filter = %QueryFilter{id: <<42::128>>, limit: 10}
+      query_filter = %QueryFilter{ledger: 42, limit: 10}
 
       TigerBeetlex.Connection.query_transfers(:tb, query_filter)
       #=> {:ok, [%TigerBeetlex.Transfer{}]}

--- a/lib/tigerbeetlex/id.ex
+++ b/lib/tigerbeetlex/id.ex
@@ -16,6 +16,16 @@ defmodule TigerBeetlex.ID do
     Server.generate_id()
   end
 
+  @doc """
+  Converts an integer to a 128 bit binary id.
+
+  The integer is formatted in little endian format so that the correct ordering is preserved in
+  TigerBeetle LSM trees.
+  """
+  def from_int(n) when is_integer(n) and n >= 0 do
+    <<n::unsigned-integer-little-size(128)>>
+  end
+
   @doc false
   def validate(<<_::128>> = value), do: {:ok, value}
   def validate(_other), do: {:error, "not a valid 128-bit binary"}

--- a/test/concurrency_test.exs
+++ b/test/concurrency_test.exs
@@ -7,7 +7,7 @@ defmodule TigerBeetlex.ConcurrencyTest do
   alias TigerBeetlex.Response
 
   setup do
-    {:ok, client} = Client.new(<<0::128>>, ["3000"])
+    {:ok, client} = Client.new(ID.from_int(0), ["3000"])
 
     {:ok, client: client}
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -24,7 +24,7 @@ defmodule TigerBeetlex.IntegrationTest do
 
     args = [
       name: name,
-      cluster_id: <<0::128>>,
+      cluster_id: ID.from_int(0),
       addresses: ["3000"]
     ]
 
@@ -92,7 +92,7 @@ defmodule TigerBeetlex.IntegrationTest do
 
     test "failed account creation", %{conn: conn} do
       account = %Account{
-        id: <<0::128>>,
+        id: ID.from_int(0),
         ledger: 1,
         code: 1,
         flags: %AccountFlags{credits_must_not_exceed_debits: true}
@@ -656,7 +656,7 @@ defmodule TigerBeetlex.IntegrationTest do
         conn: conn
       } = ctx
 
-      non_existing_id = <<42::128>>
+      non_existing_id = ID.from_int(42)
 
       assert {:ok, []} = Connection.lookup_accounts(conn, [non_existing_id])
     end
@@ -667,7 +667,7 @@ defmodule TigerBeetlex.IntegrationTest do
         conn: conn
       } = ctx
 
-      non_existing_id = <<42::128>>
+      non_existing_id = ID.from_int(42)
       account_ids = [non_existing_id, account_id]
 
       assert {:ok, results} = Connection.lookup_accounts(conn, account_ids)
@@ -709,7 +709,7 @@ defmodule TigerBeetlex.IntegrationTest do
         conn: conn
       } = ctx
 
-      non_existing_id = <<42::128>>
+      non_existing_id = ID.from_int(42)
 
       assert {:ok, []} = Connection.lookup_transfers(conn, [non_existing_id])
     end
@@ -720,7 +720,7 @@ defmodule TigerBeetlex.IntegrationTest do
         conn: conn
       } = ctx
 
-      non_existing_id = <<42::128>>
+      non_existing_id = ID.from_int(42)
       transfer_ids = [non_existing_id, transfer_id]
 
       assert {:ok, results} = Connection.lookup_transfers(conn, transfer_ids)

--- a/test/tigerbeetlex/client_test.exs
+++ b/test/tigerbeetlex/client_test.exs
@@ -4,31 +4,32 @@ defmodule Tigerbeetlex.ClientTest do
   alias TigerBeetlex.Account
   alias TigerBeetlex.Client
   alias TigerBeetlex.CreateAccountsResult
+  alias TigerBeetlex.ID
 
   describe "new/2" do
     test "returns a client with valid parameters" do
-      assert {:ok, %Client{}} = Client.new(<<0::128>>, ["3000"])
+      assert {:ok, %Client{}} = Client.new(ID.from_int(0), ["3000"])
     end
 
     test "returns :invalid_address for invalid address" do
-      assert {:error, :invalid_address} = Client.new(<<0::128>>, ["foobar"])
+      assert {:error, :invalid_address} = Client.new(ID.from_int(0), ["foobar"])
     end
 
     test "returns :address_limit_exceeded for too many addresses" do
       addresses = Enum.map(3000..3010, &to_string/1)
-      assert {:error, :address_limit_exceeded} = Client.new(<<0::128>>, addresses)
+      assert {:error, :address_limit_exceeded} = Client.new(ID.from_int(0), addresses)
     end
   end
 
   describe "receive_and_decode/1" do
     setup do
-      {:ok, client} = Client.new(<<0::128>>, ["3000"])
+      {:ok, client} = Client.new(ID.from_int(0), ["3000"])
 
       %{client: client}
     end
 
     test "blocks on the request and returns the result", %{client: client} do
-      accounts = [%Account{id: <<0::128>>, ledger: 3, code: 4}]
+      accounts = [%Account{id: ID.from_int(0), ledger: 3, code: 4}]
 
       {:ok, ref} = Client.create_accounts(client, accounts)
 

--- a/test/tigerbeetlex/connection_test.exs
+++ b/test/tigerbeetlex/connection_test.exs
@@ -2,12 +2,13 @@ defmodule TigerBeetlex.ConnectionTest do
   use ExUnit.Case, async: true
 
   alias TigerBeetlex.Connection
+  alias TigerBeetlex.ID
 
   describe "start_link/1" do
     setup do
       valid_opts = [
         name: :tb_connection_test,
-        cluster_id: <<0::128>>,
+        cluster_id: ID.from_int(0),
         addresses: ["3000"]
       ]
 

--- a/test/tigerbeetlex/id_test.exs
+++ b/test/tigerbeetlex/id_test.exs
@@ -1,5 +1,5 @@
 defmodule TigerBeetlex.IDTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias TigerBeetlex.ID
 
@@ -8,6 +8,12 @@ defmodule TigerBeetlex.IDTest do
       ids = Enum.map(1..100, fn _ -> ID.generate() end)
 
       assert_strictly_monotonic(ids)
+    end
+  end
+
+  describe "from_int/1" do
+    test "encodes the integer in little endian" do
+      assert ID.from_int(42) == <<42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
     end
   end
 


### PR DESCRIPTION
Provide a unified way to transform an int to an ID instead of manually having to serialize the int to a binary