### PR TITLE
feat: improve atomics in ID generation

### DIFF
--- a/test/tigerbeetlex/id_test.exs
+++ b/test/tigerbeetlex/id_test.exs
@@ -5,7 +5,7 @@ defmodule TigerBeetlex.IDTest do
 
   describe "generate/0" do
     test "generates strictly monotonic IDs when called serially" do
-      ids = Enum.map(1..100, fn _ -> ID.generate() end)
+      ids = Enum.map(1..10_000, fn _ -> ID.generate() end)
 
       assert_strictly_monotonic(ids)
     end


### PR DESCRIPTION
Use the full 80 bits of randomness by splitting the random value in two atomics and manually carrying over when incrementing, similar to how other TigerBeetle clients handle this